### PR TITLE
Init cache "element queue" before use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `ipinfolaravel` will be documented in this file.
 
+## v2.1.1
+
+- Fixed https://github.com/ipinfo/laravel/issues/14 with
+  https://github.com/ipinfo/laravel/pull/15.
+
 ## v2.1.0
 
 - Update to the latest IPinfo PHP package, which supports PHP 8 and deprecates

--- a/src/DefaultCache.php
+++ b/src/DefaultCache.php
@@ -18,7 +18,7 @@ class DefaultCache implements CacheInterface
 
     public function __construct(int $maxsize, int $ttl)
     {
-        $this->element_queue;
+        $this->element_queue = array();
         $this->maxsize = $maxsize;
         $this->ttl = $ttl;
     }


### PR DESCRIPTION
Otherwise if the app is started while keys _do_ exist, and the first key searched exists, there will be an error inside `manageSize`.

Closes #14 