### PR TITLE
Initialize php sdk client once at config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `ipinfolaravel` will be documented in this file.
 
+## v2.1.3
+
+- The IPinfo PHP SDK will no longer be initialized multiple times - one will be
+  initialized at application startup and used throughout.
+
 ## v2.1.2
 
 - Use v2.1.1 of PHP SDK (https://github.com/ipinfo/php/releases/tag/v2.1.1).

--- a/src/ipinfolaravel.php
+++ b/src/ipinfolaravel.php
@@ -42,8 +42,7 @@ class ipinfolaravel
         if ($this->filter && call_user_func($this->filter, $request)) {
             $details = null;
         } else {
-            $ipinfo = new IPinfoClient($this->access_token, $this->settings);
-            $details = $ipinfo->getDetails($request->ip());
+            $details = $this->ipinfo->getDetails($request->ip());
         }
 
         $request->request->set('ipinfo', $details);
@@ -70,6 +69,8 @@ class ipinfolaravel
             $ttl = config('services.ipinfo.cache_ttl', self::CACHE_TTL);
             $this->settings['cache'] = new DefaultCache($maxsize, $ttl);
         }
+
+        $this->ipinfo = new IPinfoClient($this->access_token, $this->settings);
     }
 
     /**


### PR DESCRIPTION
Right now it's being initialized _on each request_!

One side effect of this change is that the PHP SDK client will actually start to build up its own internal cache now, whereas before it was getting repeatedly created & destroyed before anything could be used.

Another is that each request will be handled much faster...