### PR TITLE
Fix deprecation warnings and improve property handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "homepage": "https://github.com/ipinfo/ipinfolaravel",
     "keywords": ["Laravel", "ipinfolaravel"],
     "require": {
-        "illuminate/support": ">=7 <11",
+        "illuminate/support": ">=7 <12",
         "ipinfo/ipinfo": "^3.1.0"
     },
     "require-dev": {


### PR DESCRIPTION
- Explicitly declare the `$ipinfo` and `$no_except` properties to avoid dynamic creation which is deprecated as of PHP 8.2.
- Update the docblock for the `$filter` property to accurately represent its type as `callable`.
- Ensure that all class properties are initialized properly to prevent runtime errors and adhere to stricter PHP standards.