### PR TITLE
Properly add support for Laravel 12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ["8.1", "8.2", "8.3", "8.4"]
+        php: ["8.3", "8.4"]
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,13 @@
     "homepage": "https://github.com/ipinfo/ipinfolaravel",
     "keywords": ["Laravel", "ipinfolaravel"],
     "require": {
-        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0",
+        "illuminate/support": "^7.0|^8.0|^9.0|^10.0|^11.0|^12.0",
         "ipinfo/ipinfo": "^3.2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^12.0",
         "mockery/mockery": "^1.4.2",
-        "orchestra/testbench": "^8.36",
-        "sempro/phpunit-pretty-print": "^1.3.0",
+        "orchestra/testbench": "^10.6",
         "squizlabs/php_codesniffer": "^3.5.8"
     },
     "autoload": {
@@ -37,7 +36,7 @@
     "scripts": {
         "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src config",
         "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src config",
-        "test": "phpunit --colors=always --coverage-html=coverage"
+        "test": "phpunit --colors=always"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "scripts": {
         "check-style": "phpcs -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src config",
         "fix-style": "phpcbf -p --standard=PSR2 --runtime-set ignore_errors_on_exit 1 --runtime-set ignore_warnings_on_exit 1 src config",
-        "test": "phpunit --colors=always"
+        "test": "phpunit --colors=always --coverage-html=coverage"
     },
     "extra": {
         "laravel": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.0/phpunit.xsd">
+
+  <source>
     <include>
-      <directory suffix=".php">src/</directory>
+      <directory suffix=".php">src</directory>
     </include>
-  </coverage>
+  </source>
+
   <testsuites>
     <testsuite name="ipinfo-laravel Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+
   <logging>
     <junit outputFile="build/report.junit.xml"/>
   </logging>


### PR DESCRIPTION
Closes #66.

I though it was added already but releasing while releasing that I must have botched some merge and lost the upgrade.