### PR TITLE
Add documentation for Core and Plus bundles and resproxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,59 @@ protected $middleware = [
 ];
 ```
 
+## Core API
+
+The library also supports the [Core API](https://ipinfo.io/developers/data-types#core-data), which provides city-level geolocation with nested geo and AS objects. Authentication with your token is required.
+
+Add the following to the `Kernel::middleware` property:
+
+```php
+protected $middleware = [
+    ...
+    \ipinfo\ipinfolaravel\core\ipinfocorelaravel::class,
+];
+```
+
+## Plus API
+
+The library also supports the [Plus API](https://ipinfo.io/developers/data-types#plus-data), which provides enhanced data including mobile carrier info and privacy detection. Authentication with your token is required.
+
+Add the following to the `Kernel::middleware` property:
+
+```php
+protected $middleware = [
+    ...
+    \ipinfo\ipinfolaravel\plus\ipinfopluslaravel::class,
+];
+```
+
+## Residential Proxy API
+
+The library also supports the [Residential Proxy API](https://ipinfo.io/developers/residential-proxy-api), which allows you to check if an IP address is a residential proxy. Authentication with your token is required.
+
+Add the following to the `Kernel::middleware` property:
+
+```php
+protected $middleware = [
+    ...
+    \ipinfo\ipinfolaravel\resproxy\ipinforesproxylaravel::class,
+];
+```
+
+The residential proxy details will be available through `$request->ipinfo_resproxy`:
+
+```php
+Route::get('/', function (Request $request) {
+    $resproxy = $request->ipinfo_resproxy;
+    if ($resproxy) {
+        echo $resproxy->ip;  // 175.107.211.204
+        echo $resproxy->last_seen;  // 2025-01-20
+        echo $resproxy->percent_days_seen;  // 0.85
+        echo $resproxy->service;  // Bright Data
+    }
+});
+```
+
 ### Other Libraries
 
 There are official IPinfo client libraries available for many languages including PHP, Python, Go, Java, Ruby, and many popular frameworks such as Django, Rails, and Laravel. There are also many third-party libraries and integrations available for our API.


### PR DESCRIPTION
This PR updates the README.md with documentation for the Core and Plus bundles and the resproxy API.