### PR TITLE
fix: remove dynamic property deprecation notices

### DIFF
--- a/src/ipinfolaravel.php
+++ b/src/ipinfolaravel.php
@@ -23,15 +23,27 @@ class ipinfolaravel
 
     /**
      * Return true to skip IPinfo lookup, otherwise return false.
-     * @var function
+     * @var callable|null
      */
     public $filter = null;
 
     /**
-     * Provides ip.
+     * IP Handler interface instance.
      * @var ipinfo\ipinfolaravel\iphandler\IPHandlerInterface
      */
     public $ip_selector = null;
+
+    /**
+     * IPinfo client object.
+     * @var IPinfoClient
+     */
+    public $ipinfo = null;
+
+    /**
+     * Boolean flag to handle exceptions.
+     * @var bool
+     */
+    public $no_except = false;
 
     const CACHE_MAXSIZE = 4096;
     const CACHE_TTL = 60 * 24;
@@ -50,7 +62,7 @@ class ipinfolaravel
             $details = null;
         } else {
             try {
-                $details = $this->ipinfo->getDetails($this->ip_selector->getIP($request));                
+                $details = $this->ipinfo->getDetails($this->ip_selector->getIP($request));
             } catch (\Exception $e) {
                 $details = null;
 
@@ -58,7 +70,7 @@ class ipinfolaravel
                 // middleware unfortunately, so we catch it for them. but for
                 // backwards-compatibility, we throw the exception again unless
                 // they've told us not to.
-                if ($this->no_except != true) {
+                if (!$this->no_except) {
                     throw $e;
                 }
             }

--- a/tests/IpinfolaravelTest.php
+++ b/tests/IpinfolaravelTest.php
@@ -92,12 +92,14 @@ class IpinfolaravelTest extends TestCase
 
     public function test_handle_throws_if_client_throws_and_no_except_false()
     {
-        $this->expectException(\Exception::class);
+        $expected = new \RuntimeException('Boom! That went wrong.');
+
+        $this->expectExceptionObject($expected);
 
         $client = $this->createMock(IPinfoClient::class);
         $client
             ->method("getDetails")
-            ->willThrowException(new \Exception("fail"));
+            ->willThrowException($expected);
 
         $selector = $this->createMock(IPHandlerInterface::class);
         $selector->method("getIP")->willReturn("1.2.3.4");


### PR DESCRIPTION
This removes deprecation notices appearing in latest versions of PHP:

```
Creation of dynamic property ipinfo\ipinfolaravel\ipinfolaravel::$ipinfo is deprecated
Creation of dynamic property ipinfo\ipinfolaravel\ipinfolaravel::$no_except is deprecated
```

Replaces #63 which was never rebased.
