### PR TITLE
feat: allow swallowed exception to be logged

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,19 @@ config:
 If an exception occurs when this setting is `true`, the `$request->ipinfo`
 object will be equal to `null`.
 
+If you want the suppressed exception to be logged, you can set the
+`no_except_log_level` to a valid PSR log level. E.g. to log it as a `notice`:
+
+```php
+'ipinfo' => [
+    ...
+    'no_except' => true,
+    'no_except_log_level' => \Psr\Log\LogLevel::NOTICE,
+],
+```
+
+> The default value for `no_except_log_level` is `null`, which means that no logging will occur.
+
 ### Trying test application with Laravel Sail
 
 Install Laravel Sail with:

--- a/src/ipinfolaravel.php
+++ b/src/ipinfolaravel.php
@@ -45,6 +45,16 @@ class ipinfolaravel
      */
     public $no_except = false;
 
+    /**
+     * The log level for swallowed exceptions.
+     *
+     * Set to a valid log level, e.g. debug, info, notice etc.
+     * If null, the exception will not be logged.
+     *
+     * @var null
+     */
+    public $no_except_log_level = null;
+
     const CACHE_MAXSIZE = 4096;
     const CACHE_TTL = 60 * 24;
 
@@ -73,6 +83,10 @@ class ipinfolaravel
                 if (!$this->no_except) {
                     throw $e;
                 }
+
+                if (is_string($this->no_except_log_level)) {
+                    logger()->log($this->no_except_log_level, 'ipinfo: ' . $e->getMessage(), ['exception' => $e]);
+                }
             }
         }
 
@@ -89,6 +103,7 @@ class ipinfolaravel
         $this->access_token = config('services.ipinfo.access_token', null);
         $this->filter = config('services.ipinfo.filter', [$this, 'defaultFilter']);
         $this->no_except = config('services.ipinfo.no_except', false);
+        $this->no_except_log_level = config('services.ipinfo.no_except_log_level');
         $this->ip_selector =  config('services.ipinfo.ip_selector', new DefaultIPSelector());
 
         if ($custom_countries = config('services.ipinfo.countries_file', null)) {

--- a/tests/IpinfolaravelTest.php
+++ b/tests/IpinfolaravelTest.php
@@ -7,6 +7,9 @@ use ipinfo\ipinfo\IPinfo as IPinfoClient;
 use ipinfo\ipinfolaravel\iphandler\IPHandlerInterface;
 use Orchestra\Testbench\TestCase;
 use ipinfo\ipinfolaravel\ipinfolaravel;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 class IpinfolaravelTest extends TestCase
 {
@@ -21,6 +24,7 @@ class IpinfolaravelTest extends TestCase
         $selector,
         $filter = null,
         $noExcept = false,
+        $noExceptLogLevel = null,
     ) {
         // stub out configure() so it doesn't overwrite our mocks
         $mw = $this->getMockBuilder(ipinfolaravel::class)
@@ -31,6 +35,7 @@ class IpinfolaravelTest extends TestCase
         $mw->ip_selector = $selector;
         $mw->filter = $filter;
         $mw->no_except = $noExcept;
+        $mw->no_except_log_level = $noExceptLogLevel;
         return $mw;
     }
 
@@ -109,7 +114,7 @@ class IpinfolaravelTest extends TestCase
         $mw->handle(Request::create("/", "GET"), function () {});
     }
 
-    public function test_handle_swallows_if_client_throws_and_no_except_true()
+    public function test_handle_swallows_if_client_throws_and_no_except_true_without_logging()
     {
         $client = $this->createMock(IPinfoClient::class);
         $client
@@ -119,7 +124,42 @@ class IpinfolaravelTest extends TestCase
         $selector = $this->createMock(IPHandlerInterface::class);
         $selector->method("getIP")->willReturn("1.2.3.4");
 
+        $logger = $this->makeLog();
+        $logger->expects($this->never())->method('log');
+
         $mw = $this->makeMiddlewareWithMocks($client, $selector, null, true);
+
+        $captured = "unset";
+        $next = function ($req) use (&$captured) {
+            $captured = $req->get("ipinfo");
+            return new Response();
+        };
+
+        $mw->handle(Request::create("/", "GET"), $next);
+        $this->assertNull($captured);
+    }
+
+    public function test_handle_swallows_if_client_throws_and_no_except_true_with_logging()
+    {
+        $client = $this->createMock(IPinfoClient::class);
+        $client
+            ->method("getDetails")
+            ->willThrowException($expected = new \RuntimeException('Boom! That went wrong.'));
+
+        $selector = $this->createMock(IPHandlerInterface::class);
+        $selector->method("getIP")->willReturn("1.2.3.4");
+
+        $logger = $this->makeLog();
+        $logger
+            ->expects($this->once())
+            ->method('log')
+            ->with(
+                LogLevel::ALERT,
+                'ipinfo: ' . $expected->getMessage(),
+                ['exception' => $expected],
+            );
+
+        $mw = $this->makeMiddlewareWithMocks($client, $selector, null, true, LogLevel::ALERT);
 
         $captured = "unset";
         $next = function ($req) use (&$captured) {
@@ -149,5 +189,17 @@ class IpinfolaravelTest extends TestCase
 
         $r4 = Request::create("/", "GET");
         $this->assertFalse($mw->defaultFilter($r4));
+    }
+
+    /**
+     * @return MockObject&LoggerInterface
+     */
+    private function makeLog()
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $this->app->instance(LoggerInterface::class, $logger);
+        $this->app->instance('log', $logger);
+
+        return $logger;
     }
 }


### PR DESCRIPTION
Allows a swallowed exception to be logged at any log level. Set the `no_except_log_level` config values to a valid PSR log level for it to be logged.

By default this config value is `null`, which means do not log. This maintains backwards compatibility with the existing behaviour.

Closes #78
